### PR TITLE
Delete subscription when is rejected

### DIFF
--- a/src/actioncable.js
+++ b/src/actioncable.js
@@ -82,6 +82,7 @@ class ActionCable {
         break;
       case message_types.rejection:
         sub.callbacks.rejected();
+        delete this.subscriptions[identifier.channel];
         break;
       default:
         sub.callbacks.received(message);


### PR DESCRIPTION
If reject_subscription message is received, delete it from subscriptions
to prevent throw "Already subscribed to this channel!" on the next call.